### PR TITLE
Konfiguration für xdebug angepasst

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ You can also use Kibana to visualize Nginx & Symfony logs by visiting `http://sc
 
 # Use xdebug!
 
-To use xdebug change the line `"docker-host.localhost:127.0.0.1"` in docker-compose.yml and replace 127.0.0.1 with your machine ip addres.
 If your IDE default port is not set to 5902 you should do that, too.
 
 # Code license

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
             - ./logs/app:/var/www/app/var/log:cached
         links:
             - db
-        extra_hosts:
-            - "docker-host.localhost:127.0.0.1"
     nginx:
         build: ./nginx
         ports:

--- a/php-fpm/xdebug.ini
+++ b/php-fpm/xdebug.ini
@@ -3,4 +3,4 @@ zend_extension=xdebug.so
 [Xdebug]
 xdebug.remote_enable=true
 xdebug.remote_port=5902
-xdebug.remote_host=docker-host.localhost
+xdebug.remote_host=docker.for.mac.host.internal


### PR DESCRIPTION
Um xdebug zu nutzen muss nun keine Änderung mehr am Projekt vorgenommen werden. Es ist gegebenenfalls der Port in der IDE anzupassen.